### PR TITLE
Output information for failed tests & update expected

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,4 +112,11 @@ test {
       "ConformanceTest.deps"  : fileTree("${buildDir}/jspecify-conformance-tests/deps").join(":")
     ])
   }
+
+  testLogging {
+    showStackTraces = false
+    showStandardStreams = true
+    events "failed"
+    exceptionFormat "full"
+  }
 }

--- a/src/test/java/conformance/NullnessJSpecifyConformanceTest.java
+++ b/src/test/java/conformance/NullnessJSpecifyConformanceTest.java
@@ -8,7 +8,6 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/test/resources/jspecify-conformance-test-report.txt
+++ b/src/test/resources/jspecify-conformance-test-report.txt
@@ -1,4 +1,4 @@
-# 14 pass; 100 fail; 114 total; 12.3% score
+# 14 pass; 103 fail; 117 total; 12.0% score
 FAIL: Basic.java:28:test:expression-type:Object?:nullable
 FAIL: Basic.java:28:test:sink-type:Object!:return
 FAIL: Basic.java:28:test:cannot-convert:Object? to Object!
@@ -44,6 +44,7 @@ FAIL: irrelevantannotations/notnullmarked/Other.java:Nullable local variable arr
 FAIL: irrelevantannotations/notnullmarked/Other.java:NonNull local variable array:test:irrelevant-annotation:NonNull
 FAIL: irrelevantannotations/notnullmarked/Other.java:Nullable exception parameter:test:irrelevant-annotation:Nullable
 FAIL: irrelevantannotations/notnullmarked/Other.java:NonNull exception parameter:test:irrelevant-annotation:NonNull
+FAIL: irrelevantannotations/notnullmarked/Other.java:Intrinsically NonNull exception parameter cannot be assigned null:test:cannot-convert:null? to RuntimeException!
 FAIL: irrelevantannotations/notnullmarked/Other.java:Nullable try-with-resources:test:irrelevant-annotation:Nullable
 FAIL: irrelevantannotations/notnullmarked/Other.java:NonNull try-with-resources:test:irrelevant-annotation:NonNull
 FAIL: irrelevantannotations/notnullmarked/Other.java:Nullable exception type:test:irrelevant-annotation:Nullable
@@ -75,6 +76,7 @@ FAIL: irrelevantannotations/nullmarked/Other.java:Nullable local variable array:
 FAIL: irrelevantannotations/nullmarked/Other.java:NonNull local variable array:test:irrelevant-annotation:NonNull
 FAIL: irrelevantannotations/nullmarked/Other.java:Nullable exception parameter:test:irrelevant-annotation:Nullable
 FAIL: irrelevantannotations/nullmarked/Other.java:NonNull exception parameter:test:irrelevant-annotation:NonNull
+FAIL: irrelevantannotations/nullmarked/Other.java:Intrinsically NonNull exception parameter cannot be assigned null:test:cannot-convert:null? to RuntimeException!
 FAIL: irrelevantannotations/nullmarked/Other.java:Nullable try-with-resources:test:irrelevant-annotation:Nullable
 FAIL: irrelevantannotations/nullmarked/Other.java:NonNull try-with-resources:test:irrelevant-annotation:NonNull
 FAIL: irrelevantannotations/nullmarked/Other.java:Nullable exception type:test:irrelevant-annotation:Nullable
@@ -107,6 +109,7 @@ FAIL: irrelevantannotations/nullunmarked/Other.java:Nullable local variable arra
 FAIL: irrelevantannotations/nullunmarked/Other.java:NonNull local variable array:test:irrelevant-annotation:NonNull
 FAIL: irrelevantannotations/nullunmarked/Other.java:Nullable exception parameter:test:irrelevant-annotation:Nullable
 FAIL: irrelevantannotations/nullunmarked/Other.java:NonNull exception parameter:test:irrelevant-annotation:NonNull
+FAIL: irrelevantannotations/nullunmarked/Other.java:Intrinsically NonNull exception parameter cannot be assigned null:test:cannot-convert:null? to RuntimeException!
 FAIL: irrelevantannotations/nullunmarked/Other.java:Nullable try-with-resources:test:irrelevant-annotation:Nullable
 FAIL: irrelevantannotations/nullunmarked/Other.java:NonNull try-with-resources:test:irrelevant-annotation:NonNull
 FAIL: irrelevantannotations/nullunmarked/Other.java:Nullable exception type:test:irrelevant-annotation:Nullable


### PR DESCRIPTION
https://github.com/jspecify/jspecify/pull/508 requires an update to the expected output.
This was hard to see, because the test failure didn't contain details.