### PR TITLE
Remove CF gradle plugin dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,6 @@ plugins {
   // Code formatting; defines targets "spotlessApply" and "spotlessCheck"
   // Requires JDK 11 or higher; the plugin crashes under JDK 8.
   id 'com.diffplug.spotless' version '6.25.0'
-
-  // Checker Framework pluggable type-checking
-  id 'org.checkerframework' version '0.6.45'
 }
 
 repositories {


### PR DESCRIPTION
There are no calls to the plugin, so it doesn't seem to be used.
Let's see what CI thinks.